### PR TITLE
Update to 0.5.0

### DIFF
--- a/src/BlazorRedux/BlazorRedux.csproj
+++ b/src/BlazorRedux/BlazorRedux.csproj
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Blazor.Browser" Version="0.2.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Blazor.Browser" Version="0.5.0" />
   </ItemGroup>
 
 </Project>

--- a/src/BlazorRedux/DevToolsInterop.cs
+++ b/src/BlazorRedux/DevToolsInterop.cs
@@ -1,7 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.AspNetCore.Blazor.Browser.Interop;
+using System.Threading.Tasks;
+using Microsoft.JSInterop;
 
 namespace BlazorRedux
 {
@@ -33,7 +34,7 @@ namespace BlazorRedux
                 while (Q.Any())
                 {
                     var entry = Q.Dequeue();
-                    LogToJs(entry.Item1, entry.Item2);
+                    Task.Run(async () => await LogToJs(entry.Item1, entry.Item2));
                 }
             }
 
@@ -50,7 +51,7 @@ namespace BlazorRedux
             OnTimeTravel(new StringEventArgs(state));
         }
 
-        public static void Log(string action, string state)
+        public static async Task Log(string action, string state)
         {
             if (!_isReady)
             {
@@ -61,13 +62,13 @@ namespace BlazorRedux
             }
             else
             {
-                LogToJs(action, state);
+                await LogToJs(action, state);
             }
         }
 
-        static void LogToJs(string action, string state)
+        static async Task LogToJs(string action, string state)
         {
-            RegisteredFunction.Invoke<bool>("log", action, state);
+            await JSRuntime.Current.InvokeAsync<bool>("log", action, state);
         }
     }
 }

--- a/src/BlazorRedux/ReduxOptions.cs
+++ b/src/BlazorRedux/ReduxOptions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Microsoft.AspNetCore.Blazor;
+using Microsoft.JSInterop;
 
 namespace BlazorRedux
 {
@@ -8,8 +9,8 @@ namespace BlazorRedux
         public ReduxOptions()
         {
             // Defaults
-            StateSerializer = state => JsonUtil.Serialize(state);
-            StateDeserializer = JsonUtil.Deserialize<TState>;
+            StateSerializer = state => Json.Serialize(state);
+            StateDeserializer = Json.Deserialize<TState>;
         }
 
         public Reducer<TState, NewLocationAction> LocationReducer { get; set; }

--- a/src/BlazorRedux/Store.cs
+++ b/src/BlazorRedux/Store.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Blazor.Services;
 
 namespace BlazorRedux
@@ -28,7 +29,8 @@ namespace BlazorRedux
 
             DevToolsInterop.Reset += OnDevToolsReset;
             DevToolsInterop.TimeTravel += OnDevToolsTimeTravel;
-            DevToolsInterop.Log("initial", _options.StateSerializer(State));
+
+            Task.Run(async () => await DevToolsInterop.Log("initial", _options.StateSerializer(State)));
 
             History = new List<HistoricEntry<TState, object>>
             {
@@ -111,7 +113,8 @@ namespace BlazorRedux
             lock (_syncRoot)
             {
                 State = _rootReducer(State, action);
-                DevToolsInterop.Log(action.ToString(), _options.StateSerializer(State));
+
+                Task.Run(async () => await DevToolsInterop.Log(action.ToString(), _options.StateSerializer(State)));
                 History.Add(new HistoricEntry<TState, object>(State, action));
             }
 
@@ -134,7 +137,7 @@ namespace BlazorRedux
             lock (_syncRoot)
             {
                 State = locationReducer(State, locationAction);
-                DevToolsInterop.Log(locationAction.ToString(), _options.StateSerializer(State));
+                Task.Run(async () => await DevToolsInterop.Log(locationAction.ToString(), _options.StateSerializer(State)));
                 History.Add(new HistoricEntry<TState, object>(State, locationAction));
             }
 


### PR DESCRIPTION
These changes make it possible to use it with version 0.5.0

Update nuget package Microsoft.AspNetCore.Blazor.Browser
Use Json (JsonUtil is deprecated)